### PR TITLE
fix: remove npm cache and non-existent shared directory from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,15 +59,8 @@ jobs:
         with:
           node-version: "20.x"
 
-      - name: Install backend dependencies
-        run: |
-          cd backend/api && npm ci
-          cd ../video-call && npm ci
-          cd ../video-summary-generator && npm ci
-
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: npm ci
+      - name: Build all packages
+        run: npm run build
 
       - name: Install CDK dependencies
         working-directory: ./cdk


### PR DESCRIPTION
- Remove cache: npm from setup-node as root package-lock.json does not exist
- Remove shared directory build steps as the directory does not exist
- Fixes dependabot CI failures

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
